### PR TITLE
Add dataloaders for fetching attribute values assigned to Product, Page, and Variant

### DIFF
--- a/saleor/graphql/attribute/dataloaders.py
+++ b/saleor/graphql/attribute/dataloaders.py
@@ -1,6 +1,16 @@
 from collections import defaultdict
+from collections.abc import Iterable
+
+from django.db.models import F, Window
+from django.db.models.functions import RowNumber
 
 from ...attribute.models import Attribute, AttributeValue
+from ...attribute.models.page import AssignedPageAttributeValue
+from ...attribute.models.product import AssignedProductAttributeValue
+from ...attribute.models.product_variant import (
+    AssignedVariantAttribute,
+    AssignedVariantAttributeValue,
+)
 from ..core.dataloaders import DataLoader
 
 
@@ -47,3 +57,231 @@ class AttributeValueByIdLoader(DataLoader[int, AttributeValue]):
             self.database_connection_name
         ).in_bulk(keys)
         return [attribute_values.get(attribute_value_id) for attribute_value_id in keys]
+
+
+PRODUCT_ID = int
+PAGE_ID = int
+VARIANT_ID = int
+ATTRIBUTE_ID = int
+LIMIT = int | None
+
+
+class AttributeValuesByProductIdAndAttributeIdAndLimitLoader(
+    DataLoader[tuple[PRODUCT_ID, ATTRIBUTE_ID, LIMIT], list[AttributeValue]]
+):
+    context_key = "attribute_values_by_product_and_attribute"
+
+    def batch_load(self, keys: Iterable[tuple[PRODUCT_ID, ATTRIBUTE_ID, LIMIT]]):
+        limit_map = defaultdict(list)
+        for product_id, attribute_id, limit in keys:
+            limit_map[limit].append((product_id, attribute_id))
+
+        attribute_value_id_to_fetch_map: dict[
+            tuple[PRODUCT_ID, ATTRIBUTE_ID, LIMIT], list[int]
+        ] = defaultdict(list)
+
+        for limit, values in limit_map.items():
+            product_ids = [val[0] for val in values]
+            attribute_ids = [val[1] for val in values]
+
+            assigned_attribute_values = AssignedProductAttributeValue.objects.using(
+                self.database_connection_name
+            ).annotate(attribute_id=F("value__attribute_id"))
+            if limit is not None:
+                assigned_attribute_values = assigned_attribute_values.annotate(
+                    row_num=Window(
+                        expression=RowNumber(),
+                        partition_by=[F("attribute_id"), F("product_id")],
+                        order_by=["sort_order", "pk"],
+                    )
+                ).filter(row_num__lte=limit)
+
+            assigned_attribute_values = assigned_attribute_values.filter(
+                attribute_id__in=attribute_ids,
+                product_id__in=product_ids,
+            ).values_list("product_id", "value_id", "attribute_id")
+
+            for product_id, value_id, attribute_id in assigned_attribute_values:
+                attribute_value_id_to_fetch_map[
+                    (product_id, attribute_id, limit)
+                ].append(value_id)
+
+        attribute_value_ids_to_fetch = set()
+        for id_list in attribute_value_id_to_fetch_map.values():
+            attribute_value_ids_to_fetch.update(id_list)
+
+        def with_attribute_values(attribute_values: list[AttributeValue]):
+            attribute_value_map = {av.id: av for av in attribute_values}
+            response_data: defaultdict[
+                tuple[PRODUCT_ID, ATTRIBUTE_ID, LIMIT], list[AttributeValue]
+            ] = defaultdict(list)
+            for (
+                product_id,
+                attribute_id,
+                limit,
+            ), value_ids in attribute_value_id_to_fetch_map.items():
+                for value_id in value_ids:
+                    attr_val = attribute_value_map.get(value_id)
+                    if not attr_val:
+                        continue
+                    response_data[(product_id, attribute_id, limit)].append(attr_val)
+            return [response_data.get(key, []) for key in keys]
+
+        return (
+            AttributeValueByIdLoader(self.context)
+            .load_many(attribute_value_ids_to_fetch)
+            .then(with_attribute_values)
+        )
+
+
+class AttributeValuesByPageIdAndAttributeIdAndLimitLoader(
+    DataLoader[tuple[PAGE_ID, ATTRIBUTE_ID, LIMIT], list[AttributeValue]]
+):
+    context_key = "attribute_values_by_page_and_attribute"
+
+    def batch_load(self, keys: Iterable[tuple[PAGE_ID, ATTRIBUTE_ID, LIMIT]]):
+        limit_map = defaultdict(list)
+        for page_id, attribute_id, limit in keys:
+            limit_map[limit].append((page_id, attribute_id))
+
+        attribute_value_id_to_fetch_map: dict[
+            tuple[PAGE_ID, ATTRIBUTE_ID, LIMIT], list[int]
+        ] = defaultdict(list)
+
+        for limit, values in limit_map.items():
+            page_ids = [val[0] for val in values]
+            attribute_ids = [val[1] for val in values]
+
+            assigned_attribute_values = AssignedPageAttributeValue.objects.using(
+                self.database_connection_name
+            ).annotate(attribute_id=F("value__attribute_id"))
+            if limit is not None:
+                assigned_attribute_values = assigned_attribute_values.annotate(
+                    row_num=Window(
+                        expression=RowNumber(),
+                        partition_by=[F("attribute_id"), F("page_id")],
+                        order_by=["sort_order", "pk"],
+                    )
+                ).filter(row_num__lte=limit)
+            assigned_attribute_values = assigned_attribute_values.filter(
+                attribute_id__in=attribute_ids,
+                page_id__in=page_ids,
+            ).values_list("page_id", "value_id", "attribute_id")
+
+            for page_id, value_id, attribute_id in assigned_attribute_values:
+                attribute_value_id_to_fetch_map[(page_id, attribute_id, limit)].append(
+                    value_id
+                )
+
+        attribute_value_ids_to_fetch = set()
+        for id_list in attribute_value_id_to_fetch_map.values():
+            attribute_value_ids_to_fetch.update(id_list)
+
+        def with_attribute_values(attribute_values: list[AttributeValue]):
+            attribute_value_map = {av.id: av for av in attribute_values}
+            response_data: defaultdict[
+                tuple[PAGE_ID, ATTRIBUTE_ID, LIMIT], list[AttributeValue]
+            ] = defaultdict(list)
+            for (
+                page_id,
+                attribute_id,
+                limit,
+            ), value_ids in attribute_value_id_to_fetch_map.items():
+                for value_id in value_ids:
+                    attr_val = attribute_value_map.get(value_id)
+                    if not attr_val:
+                        continue
+                    response_data[(page_id, attribute_id, limit)].append(attr_val)
+            return [response_data.get(key, []) for key in keys]
+
+        return (
+            AttributeValueByIdLoader(self.context)
+            .load_many(attribute_value_ids_to_fetch)
+            .then(with_attribute_values)
+        )
+
+
+class AttributeValuesByVariantIdAndAttributeIdAndLimitLoader(
+    DataLoader[tuple[VARIANT_ID, ATTRIBUTE_ID, LIMIT], list[AttributeValue]]
+):
+    context_key = "attribute_values_by_variant_and_attribute"
+
+    def batch_load(self, keys: Iterable[tuple[VARIANT_ID, ATTRIBUTE_ID, LIMIT]]):
+        limit_map = defaultdict(list)
+
+        for variant_id, attribute_id, limit in keys:
+            limit_map[limit].append((variant_id, attribute_id))
+
+        attribute_value_id_to_fetch_map: dict[
+            tuple[VARIANT_ID, ATTRIBUTE_ID, LIMIT], list[int]
+        ] = defaultdict(list)
+
+        for limit, values in limit_map.items():
+            variant_ids = [val[0] for val in values]
+            attribute_ids = [val[1] for val in values]
+
+            assigned_variant_attributes = (
+                AssignedVariantAttribute.objects.using(self.database_connection_name)
+                .annotate(attribute_id=F("assignment__attribute_id"))
+                .filter(
+                    variant_id__in=variant_ids,
+                    attribute_id__in=attribute_ids,
+                )
+                .values_list("variant_id", "id", "attribute_id")
+            )
+            assigned_variant_attributes_map = {
+                id_: (variant_id, attribute_id)
+                for variant_id, id_, attribute_id in assigned_variant_attributes
+            }
+
+            assigned_variant_values = AssignedVariantAttributeValue.objects.using(
+                self.database_connection_name
+            ).filter(assignment_id__in=assigned_variant_attributes_map.keys())
+            if limit is not None:
+                assigned_variant_values = assigned_variant_values.annotate(
+                    row_num=Window(
+                        expression=RowNumber(),
+                        partition_by=F("assignment_id"),
+                        order_by=["sort_order", "pk"],
+                    )
+                ).filter(row_num__lte=limit)
+            assigned_variant_values = assigned_variant_values.values_list(
+                "value_id", "assignment_id"
+            )
+
+            for value_id, assignment_id in assigned_variant_values:
+                if assignment_id not in assigned_variant_attributes_map:
+                    continue
+                variant_id, attribute_id = assigned_variant_attributes_map[
+                    assignment_id
+                ]
+                attribute_value_id_to_fetch_map[
+                    (variant_id, attribute_id, limit)
+                ].append(value_id)
+
+        attribute_value_ids_to_fetch = set()
+        for id_list in attribute_value_id_to_fetch_map.values():
+            attribute_value_ids_to_fetch.update(id_list)
+
+        def with_attribute_values(attribute_values: list[AttributeValue]):
+            attribute_value_map = {av.id: av for av in attribute_values}
+            response_data: defaultdict[
+                tuple[VARIANT_ID, ATTRIBUTE_ID, LIMIT], list[AttributeValue]
+            ] = defaultdict(list)
+            for (
+                variant_id,
+                attribute_id,
+                limit,
+            ), value_ids in attribute_value_id_to_fetch_map.items():
+                for value_id in value_ids:
+                    attr_val = attribute_value_map.get(value_id)
+                    if not attr_val:
+                        continue
+                    response_data[(variant_id, attribute_id, limit)].append(attr_val)
+            return [response_data.get(key, []) for key in keys]
+
+        return (
+            AttributeValueByIdLoader(self.context)
+            .load_many(attribute_value_ids_to_fetch)
+            .then(with_attribute_values)
+        )

--- a/saleor/graphql/attribute/tests/queries/test_selected_attribute.py
+++ b/saleor/graphql/attribute/tests/queries/test_selected_attribute.py
@@ -1321,7 +1321,6 @@ def test_assigned_single_choice_attribute(
 
     # then
     content = get_graphql_content(response)
-
     assert len(content["data"]["page"]["assignedAttributes"]) == 1
     attr_value_data = content["data"]["page"]["assignedAttributes"][0]["value"]
     assert attr_value_data["name"] == expected_attr_value_name

--- a/saleor/graphql/attribute/types.py
+++ b/saleor/graphql/attribute/types.py
@@ -59,7 +59,12 @@ from ..translations.dataloaders import (
 )
 from ..translations.fields import TranslationField
 from ..translations.types import AttributeTranslation, AttributeValueTranslation
-from .dataloaders import AttributesByAttributeId
+from .dataloaders import (
+    AttributesByAttributeId,
+    AttributeValuesByPageIdAndAttributeIdAndLimitLoader,
+    AttributeValuesByProductIdAndAttributeIdAndLimitLoader,
+    AttributeValuesByVariantIdAndAttributeIdAndLimitLoader,
+)
 from .descriptions import AttributeDescriptions, AttributeValueDescriptions
 from .enums import AttributeEntityTypeEnum, AttributeInputTypeEnum, AttributeTypeEnum
 from .filters import (
@@ -657,6 +662,24 @@ class AttributeValueInput(BaseInputObjectType):
         doc_category = DOC_CATEGORY_ATTRIBUTES
 
 
+def get_attribute_values(
+    root: AssignedAttributeData, info: ResolveInfo, limit: int | None
+) -> Promise[list[models.AttributeValue]]:
+    if root.variant_id:
+        return AttributeValuesByVariantIdAndAttributeIdAndLimitLoader(
+            info.context
+        ).load((root.variant_id, root.attribute.node.id, limit))
+    if root.product_id:
+        return AttributeValuesByProductIdAndAttributeIdAndLimitLoader(
+            info.context
+        ).load((root.product_id, root.attribute.node.id, limit))
+    if root.page_id:
+        return AttributeValuesByPageIdAndAttributeIdAndLimitLoader(info.context).load(
+            (root.page_id, root.attribute.node.id, limit)
+        )
+    return Promise.resolve([])
+
+
 class SelectedAttribute(ChannelContextTypeForObjectType):
     attribute = graphene.Field(
         Attribute,
@@ -671,6 +694,24 @@ class SelectedAttribute(ChannelContextTypeForObjectType):
     class Meta:
         doc_category = DOC_CATEGORY_ATTRIBUTES
         description = "Represents an assigned attribute to an object."
+
+    @staticmethod
+    def resolve_values(
+        root: AssignedAttributeData, info: ResolveInfo
+    ) -> Promise[list[ChannelContext[models.AttributeValue]]]:
+        def _wrap_with_channel_context(
+            attribute_values: list[models.AttributeValue],
+        ) -> list[ChannelContext[models.AttributeValue]]:
+            if not attribute_values:
+                return []
+            return [
+                ChannelContext(node=value, channel_slug=root.attribute.channel_slug)
+                for value in attribute_values
+            ]
+
+        return get_attribute_values(root, info, limit=None).then(
+            _wrap_with_channel_context
+        )
 
 
 class AssignedAttribute(BaseInterface):
@@ -709,12 +750,17 @@ class AssignedNumericAttribute(BaseObjectType):
         doc_category = DOC_CATEGORY_ATTRIBUTES
 
     @staticmethod
-    def resolve_value(root: AssignedAttributeData, _info: ResolveInfo) -> float | None:
-        if not root.values:
-            return None
+    def resolve_value(
+        root: AssignedAttributeData, info: ResolveInfo
+    ) -> Promise[float | None]:
+        def get_numeric_value(
+            attribute_values: list[models.AttributeValue],
+        ) -> float | None:
+            if not attribute_values:
+                return None
+            return attribute_values[0].numeric
 
-        attr_value = root.values[0].node
-        return attr_value.numeric
+        return get_attribute_values(root, info, limit=1).then(get_numeric_value)
 
 
 class AssignedTextAttribute(BaseObjectType):
@@ -740,31 +786,39 @@ class AssignedTextAttribute(BaseObjectType):
         doc_category = DOC_CATEGORY_ATTRIBUTES
 
     @staticmethod
-    def resolve_value(root: AssignedAttributeData, _info: ResolveInfo) -> JSON | None:
-        if not root.values:
-            return None
-        attr_value = root.values[0].node
-        return attr_value.rich_text
+    def resolve_value(
+        root: AssignedAttributeData, info: ResolveInfo
+    ) -> Promise[JSON | None]:
+        def get_rich_text(attribute_values: list[models.AttributeValue]) -> JSON | None:
+            if not attribute_values:
+                return None
+            return attribute_values[0].rich_text
+
+        return get_attribute_values(root, info, limit=1).then(get_rich_text)
 
     @staticmethod
     def resolve_translation(
         root: AssignedAttributeData, info: ResolveInfo, *, language_code
-    ) -> Promise[JSON | None] | None:
-        if not root.values:
-            return None
-
-        def _wrap_translation(
+    ) -> Promise[Promise[JSON | None] | None]:
+        def get_translation(
             translation: AttributeValueTranslation | None,
         ) -> JSON | None:
             if translation is None:
                 return None
             return translation.rich_text
 
-        return (
-            AttributeValueTranslationByIdAndLanguageCodeLoader(info.context)
-            .load((root.values[0].node.id, language_code))
-            .then(_wrap_translation)
-        )
+        def with_attribute_value(
+            attribute_values: list[models.AttributeValue],
+        ) -> Promise[JSON | None] | None:
+            if not attribute_values:
+                return None
+            return (
+                AttributeValueTranslationByIdAndLanguageCodeLoader(info.context)
+                .load((attribute_values[0].id, language_code))
+                .then(get_translation)
+            )
+
+        return get_attribute_values(root, info, limit=1).then(with_attribute_value)
 
 
 class AssignedPlainTextAttribute(BaseObjectType):
@@ -789,31 +843,39 @@ class AssignedPlainTextAttribute(BaseObjectType):
         doc_category = DOC_CATEGORY_ATTRIBUTES
 
     @staticmethod
-    def resolve_value(root: AssignedAttributeData, _info: ResolveInfo) -> str | None:
-        if not root.values:
-            return None
-        attr_value = root.values[0].node
-        return attr_value.plain_text
+    def resolve_value(
+        root: AssignedAttributeData, info: ResolveInfo
+    ) -> Promise[str | None]:
+        def get_plain_text(attribute_values: list[models.AttributeValue]) -> str | None:
+            if not attribute_values:
+                return None
+            return attribute_values[0].plain_text
+
+        return get_attribute_values(root, info, limit=1).then(get_plain_text)
 
     @staticmethod
     def resolve_translation(
         root: AssignedAttributeData, info: ResolveInfo, *, language_code
-    ) -> Promise[str | None] | None:
-        if not root.values:
-            return None
-
-        def _wrap_translation(
+    ) -> Promise[Promise[str | None] | None]:
+        def get_translation(
             translation: AttributeValueTranslation | None,
         ) -> str | None:
             if translation is None:
                 return None
             return translation.plain_text
 
-        return (
-            AttributeValueTranslationByIdAndLanguageCodeLoader(info.context)
-            .load((root.values[0].node.id, language_code))
-            .then(_wrap_translation)
-        )
+        def with_attribute_value(
+            attribute_values: list[models.AttributeValue],
+        ) -> Promise[str | None] | None:
+            if not attribute_values:
+                return None
+            return (
+                AttributeValueTranslationByIdAndLanguageCodeLoader(info.context)
+                .load((attribute_values[0].id, language_code))
+                .then(get_translation)
+            )
+
+        return get_attribute_values(root, info, limit=1).then(with_attribute_value)
 
 
 class AssignedFileAttribute(BaseObjectType):
@@ -825,11 +887,18 @@ class AssignedFileAttribute(BaseObjectType):
         doc_category = DOC_CATEGORY_ATTRIBUTES
 
     @staticmethod
-    def resolve_value(root: AssignedAttributeData, _info: ResolveInfo) -> File | None:
-        if not root.values:
-            return None
-        attr_value = root.values[0].node
-        return File(url=attr_value.file_url, content_type=attr_value.content_type)
+    def resolve_value(
+        root: AssignedAttributeData, info: ResolveInfo
+    ) -> Promise[File | None]:
+        def get_file(attribute_values: list[models.AttributeValue]) -> File | None:
+            if not attribute_values:
+                return None
+            return File(
+                url=attribute_values[0].file_url,
+                content_type=attribute_values[0].content_type,
+            )
+
+        return get_attribute_values(root, info, limit=1).then(get_file)
 
 
 class AssignedSinglePageReferenceAttribute(BaseObjectType):
@@ -847,18 +916,23 @@ class AssignedSinglePageReferenceAttribute(BaseObjectType):
     @staticmethod
     def resolve_value(
         root: AssignedAttributeData, info: ResolveInfo
-    ) -> Promise[ChannelContext[page_models.Page]] | None:
-        if not root.values:
-            return None
+    ) -> Promise[Promise[ChannelContext[page_models.Page]] | None]:
+        def get_page(
+            attribute_values: list[models.AttributeValue],
+        ) -> Promise[ChannelContext[page_models.Page]] | None:
+            if not attribute_values:
+                return None
+            referenced_value = attribute_values[0]
+            if not referenced_value.reference_page_id:
+                return None
+            channel_slug = root.attribute.channel_slug
+            return (
+                PageByIdLoader(info.context)
+                .load(referenced_value.reference_page_id)
+                .then(lambda page: ChannelContext(node=page, channel_slug=channel_slug))
+            )
 
-        channel_slug = root.attribute.channel_slug
-        attr_value = root.values[0].node
-
-        return (
-            PageByIdLoader(info.context)
-            .load(attr_value.reference_page_id)
-            .then(lambda page: ChannelContext(node=page, channel_slug=channel_slug))
-        )
+        return get_attribute_values(root, info, limit=1).then(get_page)
 
 
 class AssignedSingleProductReferenceAttribute(BaseObjectType):
@@ -876,20 +950,27 @@ class AssignedSingleProductReferenceAttribute(BaseObjectType):
     @staticmethod
     def resolve_value(
         root: AssignedAttributeData, info: ResolveInfo
-    ) -> Promise[ChannelContext[product_models.Product]] | None:
-        if not root.values:
-            return None
-
-        channel_slug = root.attribute.channel_slug
-        attr_value = root.values[0].node
-
-        return (
-            ProductByIdLoader(info.context)
-            .load(attr_value.reference_product_id)
-            .then(
-                lambda product: ChannelContext(node=product, channel_slug=channel_slug)
+    ) -> Promise[Promise[ChannelContext[product_models.Product]] | None]:
+        def get_product(
+            attribute_values: list[models.AttributeValue],
+        ) -> Promise[ChannelContext[product_models.Product]] | None:
+            if not attribute_values:
+                return None
+            referenced_value = attribute_values[0]
+            if not referenced_value.reference_product_id:
+                return None
+            channel_slug = root.attribute.channel_slug
+            return (
+                ProductByIdLoader(info.context)
+                .load(referenced_value.reference_product_id)
+                .then(
+                    lambda product: ChannelContext(
+                        node=product, channel_slug=channel_slug
+                    )
+                )
             )
-        )
+
+        return get_attribute_values(root, info, limit=1).then(get_product)
 
 
 class AssignedSingleProductVariantReferenceAttribute(BaseObjectType):
@@ -909,22 +990,28 @@ class AssignedSingleProductVariantReferenceAttribute(BaseObjectType):
     @staticmethod
     def resolve_value(
         root: AssignedAttributeData, info: ResolveInfo
-    ) -> Promise[ChannelContext[product_models.ProductVariant]] | None:
-        if not root.values:
-            return None
+    ) -> Promise[Promise[ChannelContext[product_models.ProductVariant]] | None]:
+        def get_variant(
+            attribute_values: list[models.AttributeValue],
+        ) -> Promise[ChannelContext[product_models.ProductVariant]] | None:
+            if not attribute_values:
+                return None
+            attr_value = attribute_values[0]
+            if not attr_value.reference_variant_id:
+                return None
 
-        channel_slug = root.attribute.channel_slug
-        attr_value = root.values[0].node
-
-        return (
-            ProductVariantByIdLoader(info.context)
-            .load(attr_value.reference_variant_id)
-            .then(
-                lambda product_variant: ChannelContext(
-                    node=product_variant, channel_slug=channel_slug
+            channel_slug = root.attribute.channel_slug
+            return (
+                ProductVariantByIdLoader(info.context)
+                .load(attr_value.reference_variant_id)
+                .then(
+                    lambda product_variant: ChannelContext(
+                        node=product_variant, channel_slug=channel_slug
+                    )
                 )
             )
-        )
+
+        return get_attribute_values(root, info, limit=1).then(get_variant)
 
 
 class AssignedSingleCategoryReferenceAttribute(BaseObjectType):
@@ -942,11 +1029,20 @@ class AssignedSingleCategoryReferenceAttribute(BaseObjectType):
     @staticmethod
     def resolve_value(
         root: AssignedAttributeData, info: ResolveInfo
-    ) -> Promise[product_models.Category] | None:
-        if not root.values:
-            return None
-        attr_value = root.values[0].node
-        return CategoryByIdLoader(info.context).load(attr_value.reference_category_id)
+    ) -> Promise[Promise[product_models.Category] | None]:
+        def get_category(
+            attribute_values: list[models.AttributeValue],
+        ) -> Promise[product_models.Category] | None:
+            if not attribute_values:
+                return None
+            attr_value = attribute_values[0]
+            if not attr_value.reference_category_id:
+                return None
+            return CategoryByIdLoader(info.context).load(
+                attr_value.reference_category_id
+            )
+
+        return get_attribute_values(root, info, limit=1).then(get_category)
 
 
 class AssignedSingleCollectionReferenceAttribute(BaseObjectType):
@@ -964,22 +1060,27 @@ class AssignedSingleCollectionReferenceAttribute(BaseObjectType):
     @staticmethod
     def resolve_value(
         root: AssignedAttributeData, info: ResolveInfo
-    ) -> Promise[ChannelContext[product_models.Collection]] | None:
-        if not root.values:
-            return None
-
-        channel_slug = root.attribute.channel_slug
-        attr_value = root.values[0].node
-
-        return (
-            CollectionByIdLoader(info.context)
-            .load(attr_value.reference_collection_id)
-            .then(
-                lambda collection: ChannelContext(
-                    node=collection, channel_slug=channel_slug
+    ) -> Promise[Promise[ChannelContext[product_models.Collection]] | None]:
+        def get_collection(
+            attribute_values: list[models.AttributeValue],
+        ) -> Promise[ChannelContext[product_models.Collection]] | None:
+            if not attribute_values:
+                return None
+            attr_value = attribute_values[0]
+            if not attr_value.reference_collection_id:
+                return None
+            channel_slug = root.attribute.channel_slug
+            return (
+                CollectionByIdLoader(info.context)
+                .load(attr_value.reference_collection_id)
+                .then(
+                    lambda collection: ChannelContext(
+                        node=collection, channel_slug=channel_slug
+                    )
                 )
             )
-        )
+
+        return get_attribute_values(root, info, limit=1).then(get_collection)
 
 
 class AssignedMultiPageReferenceAttribute(BaseObjectType):
@@ -1006,28 +1107,34 @@ class AssignedMultiPageReferenceAttribute(BaseObjectType):
         root: AssignedAttributeData,
         info: ResolveInfo,
         limit: int = DEFAULT_NESTED_LIST_LIMIT,
-    ) -> Promise[list[ChannelContext[page_models.Page]]]:
-        if not root.values:
-            return Promise.resolve([])
-
-        channel_slug = root.attribute.channel_slug
-        attr_values = [value.node for value in root.values]
-        attr_values = attr_values[:limit]
-
+    ) -> Promise[Promise[list[ChannelContext[page_models.Page]]]]:
         def _wrap_with_channel_context(
             pages: list[page_models.Page],
         ) -> list[ChannelContext[page_models.Page]]:
             if not pages:
                 return []
             return [
-                ChannelContext(node=page, channel_slug=channel_slug) for page in pages
+                ChannelContext(node=page, channel_slug=root.attribute.channel_slug)
+                for page in pages
             ]
 
-        return (
-            PageByIdLoader(info.context)
-            .load_many([value.reference_page_id for value in attr_values])
-            .then(_wrap_with_channel_context)
-        )
+        def get_pages(
+            attribute_values: list[models.AttributeValue],
+        ) -> Promise[list[ChannelContext[page_models.Page]]]:
+            if not attribute_values:
+                return Promise.resolve([])
+            page_ids = [
+                value.reference_page_id
+                for value in attribute_values
+                if value.reference_page_id
+            ]
+            return (
+                PageByIdLoader(info.context)
+                .load_many(page_ids)
+                .then(_wrap_with_channel_context)
+            )
+
+        return get_attribute_values(root, info, limit=limit).then(get_pages)
 
 
 class AssignedMultiProductReferenceAttribute(BaseObjectType):
@@ -1054,29 +1161,34 @@ class AssignedMultiProductReferenceAttribute(BaseObjectType):
         root: AssignedAttributeData,
         info: ResolveInfo,
         limit: int = DEFAULT_NESTED_LIST_LIMIT,
-    ) -> Promise[list[ChannelContext[product_models.Product]]]:
-        if not root.values:
-            return Promise.resolve([])
-
-        channel_slug = root.attribute.channel_slug
-        attr_values = [value.node for value in root.values]
-        attr_values = attr_values[:limit]
-
+    ) -> Promise[Promise[list[ChannelContext[product_models.Product]]]]:
         def _wrap_with_channel_context(
             products: list[product_models.Product],
         ) -> list[ChannelContext[product_models.Product]]:
             if not products:
                 return []
             return [
-                ChannelContext(node=product, channel_slug=channel_slug)
+                ChannelContext(node=product, channel_slug=root.attribute.channel_slug)
                 for product in products
             ]
 
-        return (
-            ProductByIdLoader(info.context)
-            .load_many([value.reference_product_id for value in attr_values])
-            .then(_wrap_with_channel_context)
-        )
+        def get_products(
+            attribute_values: list[models.AttributeValue],
+        ) -> Promise[list[ChannelContext[product_models.Product]]]:
+            if not attribute_values:
+                return Promise.resolve([])
+            product_ids = [
+                value.reference_product_id
+                for value in attribute_values
+                if value.reference_product_id
+            ]
+            return (
+                ProductByIdLoader(info.context)
+                .load_many(product_ids)
+                .then(_wrap_with_channel_context)
+            )
+
+        return get_attribute_values(root, info, limit=limit).then(get_products)
 
 
 class AssignedMultiProductVariantReferenceAttribute(BaseObjectType):
@@ -1105,29 +1217,35 @@ class AssignedMultiProductVariantReferenceAttribute(BaseObjectType):
         root: AssignedAttributeData,
         info: ResolveInfo,
         limit: int = DEFAULT_NESTED_LIST_LIMIT,
-    ) -> Promise[list[ChannelContext[product_models.ProductVariant]]]:
-        if not root.values:
-            return Promise.resolve([])
-
-        channel_slug = root.attribute.channel_slug
-        attr_values = [value.node for value in root.values]
-        attr_values = attr_values[:limit]
-
+    ) -> Promise[Promise[list[ChannelContext[product_models.ProductVariant]]]]:
         def _wrap_with_channel_context(
             variants: list[product_models.ProductVariant],
         ) -> list[ChannelContext[product_models.ProductVariant]]:
             if not variants:
                 return []
             return [
-                ChannelContext(node=variant, channel_slug=channel_slug)
+                ChannelContext(node=variant, channel_slug=root.attribute.channel_slug)
                 for variant in variants
             ]
 
-        return (
-            ProductVariantByIdLoader(info.context)
-            .load_many([value.reference_variant_id for value in attr_values])
-            .then(_wrap_with_channel_context)
-        )
+        def get_variants(
+            attribute_values: list[models.AttributeValue],
+        ) -> Promise[list[ChannelContext[product_models.ProductVariant]]]:
+            if not attribute_values:
+                return Promise.resolve([])
+
+            variant_ids = [
+                value.reference_variant_id
+                for value in attribute_values
+                if value.reference_variant_id
+            ]
+            return (
+                ProductVariantByIdLoader(info.context)
+                .load_many(variant_ids)
+                .then(_wrap_with_channel_context)
+            )
+
+        return get_attribute_values(root, info, limit=limit).then(get_variants)
 
 
 class AssignedMultiCategoryReferenceAttribute(BaseObjectType):
@@ -1154,15 +1272,21 @@ class AssignedMultiCategoryReferenceAttribute(BaseObjectType):
         root: AssignedAttributeData,
         info: ResolveInfo,
         limit: int = DEFAULT_NESTED_LIST_LIMIT,
-    ) -> Promise[list[product_models.Category]]:
-        if not root.values:
-            return Promise.resolve([])
-        attr_values = [value.node for value in root.values]
-        attr_values = attr_values[:limit]
+    ) -> Promise[Promise[list[product_models.Category]]]:
+        def get_categories(
+            attribute_values: list[models.AttributeValue],
+        ) -> Promise[list[product_models.Category]]:
+            if not attribute_values:
+                return Promise.resolve([])
 
-        return CategoryByIdLoader(info.context).load_many(
-            [value.reference_category_id for value in attr_values]
-        )
+            category_ids = [
+                value.reference_category_id
+                for value in attribute_values
+                if value.reference_category_id
+            ]
+            return CategoryByIdLoader(info.context).load_many(category_ids)
+
+        return get_attribute_values(root, info, limit=limit).then(get_categories)
 
 
 class AssignedMultiCollectionReferenceAttribute(BaseObjectType):
@@ -1189,29 +1313,37 @@ class AssignedMultiCollectionReferenceAttribute(BaseObjectType):
         root: AssignedAttributeData,
         info: ResolveInfo,
         limit: int = DEFAULT_NESTED_LIST_LIMIT,
-    ) -> Promise[list[ChannelContext[product_models.Collection]]]:
-        if not root.values:
-            return Promise.resolve([])
-
-        channel_slug = root.attribute.channel_slug
-        attr_values = [value.node for value in root.values]
-        attr_values = attr_values[:limit]
-
+    ) -> Promise[Promise[list[ChannelContext[product_models.Collection]]]]:
         def _wrap_with_channel_context(
             collections: list[product_models.Collection],
         ) -> list[ChannelContext[product_models.Collection]]:
             if not collections:
                 return []
             return [
-                ChannelContext(node=collection, channel_slug=channel_slug)
+                ChannelContext(
+                    node=collection, channel_slug=root.attribute.channel_slug
+                )
                 for collection in collections
             ]
 
-        return (
-            CollectionByIdLoader(info.context)
-            .load_many([value.reference_collection_id for value in attr_values])
-            .then(_wrap_with_channel_context)
-        )
+        def get_collections(
+            attribute_values: list[models.AttributeValue],
+        ) -> Promise[list[ChannelContext[product_models.Collection]]]:
+            if not attribute_values:
+                return Promise.resolve([])
+
+            collection_ids = [
+                value.reference_collection_id
+                for value in attribute_values
+                if value.reference_collection_id
+            ]
+            return (
+                CollectionByIdLoader(info.context)
+                .load_many(collection_ids)
+                .then(_wrap_with_channel_context)
+            )
+
+        return get_attribute_values(root, info, limit=limit).then(get_collections)
 
 
 class AssignedChoiceAttributeValue(BaseObjectType):
@@ -1255,13 +1387,18 @@ class AssignedSingleChoiceAttribute(BaseObjectType):
         description = "Represents a single choice attribute." + ADDED_IN_322
         doc_category = DOC_CATEGORY_ATTRIBUTES
 
+    @staticmethod
     def resolve_value(
         root: AssignedAttributeData, info: ResolveInfo
-    ) -> models.AttributeValue | None:
-        if not root.values:
-            return None
-        attr_value = root.values[0].node
-        return attr_value
+    ) -> Promise[models.AttributeValue | None]:
+        def get_single_choice(
+            attribute_values: list[models.AttributeValue],
+        ) -> models.AttributeValue | None:
+            if not attribute_values:
+                return None
+            return attribute_values[0]
+
+        return get_attribute_values(root, info, limit=1).then(get_single_choice)
 
 
 class AssignedMultiChoiceAttribute(BaseObjectType):
@@ -1288,9 +1425,15 @@ class AssignedMultiChoiceAttribute(BaseObjectType):
         root: AssignedAttributeData,
         info: ResolveInfo,
         limit: int = DEFAULT_NESTED_LIST_LIMIT,
-    ) -> list[models.AttributeValue]:
-        values = root.values[:limit]
-        return [value.node for value in values]
+    ) -> Promise[list[models.AttributeValue]]:
+        def get_multi_choice(
+            attribute_values: list[models.AttributeValue],
+        ) -> list[models.AttributeValue]:
+            if not attribute_values:
+                return []
+            return attribute_values
+
+        return get_attribute_values(root, info, limit=limit).then(get_multi_choice)
 
 
 class AssignedSwatchAttributeValue(BaseObjectType):
@@ -1343,12 +1486,16 @@ class AssignedSwatchAttribute(BaseObjectType):
 
     @staticmethod
     def resolve_value(
-        root: AssignedAttributeData, _info: ResolveInfo
-    ) -> models.AttributeValue | None:
-        if not root.values:
-            return None
-        attr_value = root.values[0].node
-        return attr_value
+        root: AssignedAttributeData, info: ResolveInfo
+    ) -> Promise[models.AttributeValue | None]:
+        def get_swatch(
+            attribute_values: list[models.AttributeValue],
+        ) -> models.AttributeValue | None:
+            if not attribute_values:
+                return None
+            return attribute_values[0]
+
+        return get_attribute_values(root, info, limit=1).then(get_swatch)
 
 
 class AssignedBooleanAttribute(BaseObjectType):
@@ -1363,11 +1510,15 @@ class AssignedBooleanAttribute(BaseObjectType):
         doc_category = DOC_CATEGORY_ATTRIBUTES
 
     @staticmethod
-    def resolve_value(root: AssignedAttributeData, _info: ResolveInfo) -> bool | None:
-        if not root.values:
-            return None
-        attr_value = root.values[0].node
-        return attr_value.boolean
+    def resolve_value(
+        root: AssignedAttributeData, info: ResolveInfo
+    ) -> Promise[bool | None]:
+        def get_boolean(attribute_values: list[models.AttributeValue]) -> bool | None:
+            if not attribute_values:
+                return None
+            return attribute_values[0].boolean
+
+        return get_attribute_values(root, info, limit=1).then(get_boolean)
 
 
 class AssignedDateAttribute(BaseObjectType):
@@ -1383,11 +1534,19 @@ class AssignedDateAttribute(BaseObjectType):
         doc_category = DOC_CATEGORY_ATTRIBUTES
 
     @staticmethod
-    def resolve_value(root: AssignedAttributeData, _info: ResolveInfo) -> date | None:
-        if not root.values:
-            return None
-        attr_value = root.values[0].node
-        return attr_value.date_time.date() if attr_value.date_time else None
+    def resolve_value(
+        root: AssignedAttributeData, info: ResolveInfo
+    ) -> Promise[date | None]:
+        def get_date(attribute_values: list[models.AttributeValue]) -> date | None:
+            if not attribute_values:
+                return None
+            return (
+                attribute_values[0].date_time.date()
+                if attribute_values[0].date_time
+                else None
+            )
+
+        return get_attribute_values(root, info, limit=1).then(get_date)
 
 
 class AssignedDateTimeAttribute(BaseObjectType):
@@ -1404,12 +1563,16 @@ class AssignedDateTimeAttribute(BaseObjectType):
 
     @staticmethod
     def resolve_value(
-        root: AssignedAttributeData, _info: ResolveInfo
-    ) -> datetime | None:
-        if not root.values:
-            return None
-        attr_value = root.values[0].node
-        return attr_value.date_time
+        root: AssignedAttributeData, info: ResolveInfo
+    ) -> Promise[datetime | None]:
+        def get_datetime(
+            attribute_values: list[models.AttributeValue],
+        ) -> datetime | None:
+            if not attribute_values:
+                return None
+            return attribute_values[0].date_time
+
+        return get_attribute_values(root, info, limit=1).then(get_datetime)
 
 
 ASSIGNED_SINGLE_REFERENCE_MAP = {

--- a/saleor/graphql/attribute/utils/shared.py
+++ b/saleor/graphql/attribute/utils/shared.py
@@ -31,7 +31,10 @@ T_REFERENCE = (
 @dataclass
 class AssignedAttributeData:
     attribute: ChannelContext[attribute_models.Attribute]
-    values: list[ChannelContext[attribute_models.AttributeValue]]
+
+    product_id: int | None = None
+    page_id: int | None = None
+    variant_id: int | None = None
 
 
 @dataclass

--- a/saleor/graphql/page/types.py
+++ b/saleor/graphql/page/types.py
@@ -284,15 +284,10 @@ class Page(ChannelContextType[models.Page]):
                 attribute = cast(
                     attribute_models.Attribute, attribute_data["attribute"]
                 )
-                values = cast(
-                    list[attribute_models.AttributeValue], attribute_data["values"]
-                )
                 response.append(
                     AssignedAttributeData(
                         attribute=ChannelContext(attribute, root.channel_slug),
-                        values=[
-                            ChannelContext(value, root.channel_slug) for value in values
-                        ],
+                        page_id=root.node.id,
                     )
                 )
             response = response[:limit] if limit is not None else response
@@ -333,13 +328,10 @@ class Page(ChannelContextType[models.Page]):
             if attribute_data is None:
                 return None
             attribute = cast(attribute_models.Attribute, attribute_data["attribute"])
-            values = cast(
-                list[attribute_models.AttributeValue], attribute_data["values"]
-            )
 
             return AssignedAttributeData(
                 attribute=ChannelContext(attribute, root.channel_slug),
-                values=[ChannelContext(value, root.channel_slug) for value in values],
+                page_id=root.node.id,
             )
 
         requestor = get_user_or_app_from_context(info.context)

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -642,13 +642,9 @@ class ProductVariant(ChannelContextType[models.ProductVariant]):
                 attribute = atr["attribute"]
                 attribute = cast(attribute_models.Attribute, attribute)
                 if attribute.slug == slug:
-                    values = atr["values"]
-                    values = cast(list[attribute_models.AttributeValue], values)
                     return AssignedAttributeData(
                         attribute=ChannelContext(attribute, root.channel_slug),
-                        values=[
-                            ChannelContext(value, root.channel_slug) for value in values
-                        ],
+                        variant_id=root.node.id,
                     )
             return None
 
@@ -697,10 +693,7 @@ class ProductVariant(ChannelContextType[models.ProductVariant]):
                         attribute=ChannelContext(
                             selected_att["attribute"], root.channel_slug
                         ),
-                        values=[
-                            ChannelContext(value, root.channel_slug)
-                            for value in selected_att["values"]
-                        ],
+                        variant_id=root.node.id,
                     )
                     for selected_att in selected_attributes
                 ]
@@ -734,10 +727,7 @@ class ProductVariant(ChannelContextType[models.ProductVariant]):
                     attribute=ChannelContext(
                         selected_att["attribute"], root.channel_slug
                     ),
-                    values=[
-                        ChannelContext(value, root.channel_slug)
-                        for value in selected_att["values"]
-                    ],
+                    variant_id=root.node.id,
                 )
                 for selected_att in attributes_to_return
             ]
@@ -1493,9 +1483,7 @@ class Product(ChannelContextType[models.Product]):
                     values = cast(list[attribute_models.AttributeValue], values)
                     return AssignedAttributeData(
                         attribute=ChannelContext(attribute, root.channel_slug),
-                        values=[
-                            ChannelContext(value, root.channel_slug) for value in values
-                        ],
+                        product_id=root.node.id,
                     )
             return None
 
@@ -1552,14 +1540,10 @@ class Product(ChannelContextType[models.Product]):
             for attr_data in attributes:
                 attribute = attr_data["attribute"]
                 attribute = cast(attribute_models.Attribute, attribute)
-                values = attr_data["values"]
-                values = cast(list[attribute_models.AttributeValue], values)
                 response.append(
                     AssignedAttributeData(
                         attribute=ChannelContext(attribute, root.channel_slug),
-                        values=[
-                            ChannelContext(value, root.channel_slug) for value in values
-                        ],
+                        product_id=root.node.id,
                     )
                 )
             response = response[:limit] if limit else response


### PR DESCRIPTION
Recreated from original PR: https://github.com/saleor/saleor/pull/18138

This change introduces new dataloaders that handle fetching attribute values assigned to Product, Page, and Variant.
It’s the first step toward unifying attribute resolution across the codebase.

This PR targets the feature branch. It is the first step of the work, still pending are:
- Refactoring attribute fetching to follow the same pattern as the new value dataloaders.
- Removing the old dataloaders and cleaning up legacy code.


<!-- Please mention all relevant issue numbers. -->
<!...